### PR TITLE
iOSで反応するように、クリック対象のタグに変更した

### DIFF
--- a/src/components/organisms/CopyText.vue
+++ b/src/components/organisms/CopyText.vue
@@ -15,21 +15,21 @@
         span.recipe-description {{formattedDescription}}<br>
         <br>
       template.formatted-ingredients {{formattedIngredientTitle}}<br>
-      //- ul.formatted-ingredients-list
+
       template.ingredient(v-for="ingredient in ingredients")
         span.ing-name-amount(v-if="ingredient.name&&ingredient.amount") {{ingredient.name}}  {{ingredient.amount}}<br>
       <br>
       template.formatted-steps {{formattedStepTitle}}<br>
-      //- ul.formatted-steps-list
+
       template.step(v-for="(step, index) in steps")
         template.step-description(v-if="step.description") {{index+1}}. {{step.description}}<br>
       <br>
       template.formatted-steps {{formattedMemotTitle}}<br>
-      //- ul.formatted-hashtags-list
+
       template.memo(v-for="(memo, index) in memos")
           template.memo-description(v-if="memo.description") {{index+1}}. {{memo.description}}<br>
       <br>
-      //- ul.formatted-hashtags-list
+
       template.hashtag(v-for="hashtag in hashtags")
         template.hashtag-title(v-if="hashtag.title") \#{{hashtag.title}} 
       <br>

--- a/src/components/organisms/CopyText.vue
+++ b/src/components/organisms/CopyText.vue
@@ -6,7 +6,7 @@
     .message-wrap.flex.flex-middle.end(@click="copyTexts")
       .icon
         copy-icon
-      p.copy-message クリップボードにコピー
+      button.copy-message クリップボードにコピー
     .formatted-text
       p.default-message(v-if="isNoText") レシピを入力するとコピー用のテキストが表示されます
       span.recipe


### PR DESCRIPTION
# 関連するIssue番号
- close #41 

# バグ内容
iOSではクリック対象にならないタグに@clickをつけてもイベントが発生しない。
# 修正内容
コピー用のテキストをpからbuttonに変更した。
# UIの変更点
なし
