### PR TITLE
アイコンとフォントのCSS調整

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet">
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>

--- a/src/assets/css/common.scss
+++ b/src/assets/css/common.scss
@@ -3,11 +3,11 @@
 @import "./font.scss";
 
 html {
+  font-family: -apple-system, BlinkMacSystemFont, 'Open Sans', 'Helvetica', 'Arial', sans-serif;
   background: #f8f5f2;
   color: #232323;
 }
 #app {
-  font-family: "Noto Sans JP";
   font-weight: 300;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -87,13 +87,14 @@ a {
   transition: 0.3s ease-in-out;
 }
 .icon {
-  width: 18px;
-  height: 18px;
+  width: 24px;
+  height: 24px;
+  margin-left: 5px;
 }
 
 svg {
-  max-width: 18px;
-  max-height: 18px;
+  width: 24px;
+  height: 24px;
 }
 // cssのtransition
 .fade-enter-active,

--- a/src/components/molecules/HashTagItem.vue
+++ b/src/components/molecules/HashTagItem.vue
@@ -50,10 +50,5 @@ export default Vue.extend({
     width: 175px;
     margin-left: 5px;
   }
-  .icon {
-    margin-left: 5px;
-    width: 18px;
-    height: 18px;
-  }
 }
 </style>

--- a/src/components/molecules/IngredientItem.vue
+++ b/src/components/molecules/IngredientItem.vue
@@ -62,8 +62,5 @@ export default Vue.extend({
       margin-left: 7px;
     }
   }
-  .icon {
-    margin-left: 5px;
-  }
 }
 </style>

--- a/src/components/molecules/MemoItem.vue
+++ b/src/components/molecules/MemoItem.vue
@@ -58,8 +58,5 @@ export default Vue.extend({
     width: 265px;
     margin-left: 10px;
   }
-  .icon {
-    margin-left: 5px;
-  }
 }
 </style>

--- a/src/components/molecules/StepItem.vue
+++ b/src/components/molecules/StepItem.vue
@@ -58,8 +58,5 @@ export default Vue.extend({
     width: 265px;
     margin-left: 10px;
   }
-  .icon {
-    margin-left: 5px;
-  }
 }
 </style>

--- a/src/components/organisms/CopyText.vue
+++ b/src/components/organisms/CopyText.vue
@@ -161,17 +161,13 @@ export default Vue.extend({
   position: relative;
   width: 100%;
   border-top: 1px dashed gray;
-  font-size: 12px;
+  font-size: 14px;
 
   .message-wrap {
     margin-top: 8px;
     margin-left: auto;
     .copy-message {
       margin-left: 5px;
-    }
-    .icon {
-      width: 14px;
-      height: 14px;
     }
   }
   .tool-tip {
@@ -182,7 +178,6 @@ export default Vue.extend({
     padding: 5px 10px 4px;
     background: #999;
     border-radius: 3px;
-    font-size: 12px;
     text-align: center;
     .copy-succeed-message {
       color: #fefefe;
@@ -192,7 +187,6 @@ export default Vue.extend({
     background: #fffffe;
     margin-top: 15px;
     padding: 10px 8px;
-    font-size: 14px;
     border-radius: 3px;
     .default-message {
       color: gray;

--- a/src/components/organisms/HashTagList.vue
+++ b/src/components/organisms/HashTagList.vue
@@ -61,7 +61,7 @@ export default Vue.extend({
   }
   .icon {
     margin-left: auto;
-    margin-right: 3px;
+    margin-top: 10px;
   }
 }
 </style>

--- a/src/components/organisms/IngredientList.vue
+++ b/src/components/organisms/IngredientList.vue
@@ -80,7 +80,7 @@ export default Vue.extend({
   }
   .icon {
     margin-left: auto;
-    margin-right: 3px;
+    margin-top: 10px;
   }
 }
 </style>

--- a/src/components/organisms/MemoList.vue
+++ b/src/components/organisms/MemoList.vue
@@ -67,7 +67,7 @@ export default Vue.extend({
   }
   .icon {
     margin-left: auto;
-    margin-right: 3px;
+    margin-top: 10px;
   }
 }
 </style>

--- a/src/components/organisms/StepList.vue
+++ b/src/components/organisms/StepList.vue
@@ -65,7 +65,7 @@ export default Vue.extend({
   }
   .icon {
     margin-left: auto;
-    margin-right: 3px;
+    margin-top: 10px;
   }
 }
 </style>


### PR DESCRIPTION
# 関連するIssue番号
- close #42 

# バグ内容
- ボタンが小さくて押しにくい
- iOSでフォントが設定されていない

# 修正内容
- .iconを全体的に大きめに設定
- アイコンサイズに合わせて文字サイズを調整
- Instagramに合わせてフォントを設定
