### PR TITLE
プレースホルダーの文章をよりリアルな文章に変更

### DIFF
--- a/src/components/molecules/RecipeTitle.vue
+++ b/src/components/molecules/RecipeTitle.vue
@@ -10,7 +10,7 @@
       )
       span 】
     app-textarea.description(
-      placeholder="食卓の定番料理。薄めの優しい味つけです"
+      placeholder="野菜もたくさんたべられる定番料理！一晩たつとじゃがいもに味が染みてもっとおいしくなりますよ。お弁当にもぜひどうぞ。"
       v-model="recipeItem.description"
       @input="onChangeRecipeTitle"
     )


### PR DESCRIPTION
# 関連するIssue番号
- close #76 

# 変更目的
ユーザーインタビューで、プレースホルダーの文章が実際に投稿される文章とは雰囲気が異なりイメージしにくいと言われたため。

# 変更内容
料理説明の部分のプレースホルダーを変更

# UIの変更点

|変更前|変更後|
| --- | --- |
|<img width="409" alt="スクリーンショット 2020-04-09 23 08 25" src="https://user-images.githubusercontent.com/34161352/78904126-13528380-7ab7-11ea-900c-70ab6beda898.png">|<img width="386" alt="スクリーンショット 2020-04-09 23 08 18" src="https://user-images.githubusercontent.com/34161352/78904174-206f7280-7ab7-11ea-9f48-69035bdfd005.png">|

# 影響範囲

# 動作要件

# 補足
