### PR TITLE
項目の前後入れ替え

### DIFF
--- a/src/assets/css/common.scss
+++ b/src/assets/css/common.scss
@@ -88,7 +88,6 @@ a {
 .icon {
   width: 24px;
   height: 24px;
-  margin-left: 5px;
 }
 
 svg {

--- a/src/assets/icons/Orion_arrow_down.svg
+++ b/src/assets/icons/Orion_arrow_down.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" aria-labelledby="title"
+aria-describedby="desc" role="img" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Arrow Down</title>
+  <desc>A line styled icon from Orion Icon Library.</desc>
+  <path data-name="layer2"
+  fill="none" stroke="#202020" stroke-miterlimit="10" stroke-width="2" d="M31.999 50V14"
+  stroke-linejoin="round" stroke-linecap="round"></path>
+  <path data-name="layer1" fill="none" stroke="#202020" stroke-miterlimit="10"
+  stroke-width="2" d="M18 36l14 14 14-14" stroke-linejoin="round" stroke-linecap="round"></path>
+</svg>

--- a/src/assets/icons/Orion_arrow_up.svg
+++ b/src/assets/icons/Orion_arrow_up.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" aria-labelledby="title"
+aria-describedby="desc" role="img" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Arrow Up</title>
+  <desc>A line styled icon from Orion Icon Library.</desc>
+  <path data-name="layer2"
+  fill="none" stroke="#202020" stroke-miterlimit="10" stroke-width="2" d="M32.001 14v36"
+  stroke-linejoin="round" stroke-linecap="round"></path>
+  <path data-name="layer1" fill="none" stroke="#202020" stroke-miterlimit="10"
+  stroke-width="2" d="M46 28L32 14 18 28" stroke-linejoin="round" stroke-linecap="round"></path>
+</svg>

--- a/src/components/atoms/AppSubTitle.vue
+++ b/src/components/atoms/AppSubTitle.vue
@@ -3,14 +3,14 @@
     .subtitle-wrap.flex.flex-middle
       span.sub-title ー{{title}}
       .serving-form.flex.flex-middle(v-if="title === '材料'")
-        span.blacket （
+        span.blacket (
         app-form.servingForm(
           type="text"
           placeholder="2人分"
           v-model="servingForItem"
           @input="onChangeServingFor"
         )
-        span.blacket ）
+        span.blacket )
       span ーーーーーー
 </template>
 <script lang="ts">

--- a/src/components/molecules/HashTagItem.vue
+++ b/src/components/molecules/HashTagItem.vue
@@ -47,7 +47,7 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .HashTagItem {
   .title {
-    width: 175px;
+    width: calc(100% - 38px);
     margin-left: 5px;
   }
 }

--- a/src/components/molecules/IngredientItem.vue
+++ b/src/components/molecules/IngredientItem.vue
@@ -57,10 +57,10 @@ export default Vue.extend({
 .IngredientItem {
   width: 100%;
   .wrap-icons {
-    width: 37px;
+    width: 31px;
   }
   .wrap-forms {
-    width: calc(100% - 67px);
+    width: calc(100% - 55px);
     .name {
       width: 70%;
     }
@@ -69,16 +69,9 @@ export default Vue.extend({
       margin-left: 7px;
     }
   }
-  .icon {
-    svg {
-      width: 20px;
-      height: 24px;
-      margin-left: 4px;
-    }
-  }
   .move-icon {
     svg {
-      width: 17px;
+      width: 14px;
       height: 20px;
     }
   }

--- a/src/components/molecules/IngredientItem.vue
+++ b/src/components/molecules/IngredientItem.vue
@@ -1,15 +1,20 @@
 <template lang="pug">
   .IngredientItem
-    //- move-icon
     div.flex.flex-middle
+      .wrap-icons.flex
+        i.move-icon(v-if="!isFirst")
+          up-icon(@click="onUpItem")
+        i.move-icon(v-if="!isLast")
+          down-icon(@click="onDownItem")
       .wrap-forms.flex
-        app-form.name(type="text" placeholder="じゃがいも" v-model="ingredientItem.name")
-        app-form.amount(type="text" placeholder="2つ" v-model="ingredientItem.amount")
-      i.icon(v-if="!isFirstItem")
+        app-form.name(type="text" placeholder="じゃがいも" v-model="ingredient.name")
+        app-form.amount(type="text" placeholder="2つ" v-model="ingredient.amount")
+      i.icon
         close-icon(@click="onDeleteItem")
 </template>
 <script lang="ts">
-import MoveIcon from "../../assets/icons/Orion_copy.svg";
+import UpIcon from "../../assets/icons/Orion_arrow_up.svg";
+import DownIcon from "../../assets/icons/Orion_arrow_down.svg";
 import CloseIcon from "../../assets/icons/Orion_close.svg";
 import AppForm from "../atoms/AppForm.vue";
 import Vue, { PropType } from "vue";
@@ -18,33 +23,33 @@ export type Ingredient = {
   amount: string;
 };
 
-type Data = {
-  ingredientItem: Ingredient;
-};
-
 export default Vue.extend({
   components: {
-    MoveIcon,
+    UpIcon,
+    DownIcon,
     CloseIcon,
     AppForm
   },
   props: {
     ingredient: Object as PropType<Ingredient>,
-    index: Number
-  },
-  data(): Data {
-    return {
-      ingredientItem: this.ingredient
-    };
+    index: Number,
+    isLast: Boolean
   },
   computed: {
-    isFirstItem(): boolean {
+    isFirst(): boolean {
       return this.index === 0;
     }
   },
   methods: {
     onDeleteItem(): void {
       this.$emit("on-delete-item");
+    },
+    onUpItem(): void {
+      this.$emit("on-up-item");
+    },
+    onDownItem(): void {
+      console.log("on-down-item");
+      this.$emit("on-down-item");
     }
   }
 });
@@ -52,14 +57,30 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .IngredientItem {
   width: 100%;
+  .wrap-icons {
+    width: 37px;
+  }
   .wrap-forms {
-    width: 290px;
+    width: calc(100% - 67px);
     .name {
-      width: 175px;
+      width: 70%;
     }
     .amount {
-      width: 108px;
+      width: 30%;
       margin-left: 7px;
+    }
+  }
+  .icon {
+    svg {
+      width: 20px;
+      height: 24px;
+      margin-left: 4px;
+    }
+  }
+  .move-icon {
+    svg {
+      width: 17px;
+      height: 20px;
     }
   }
 }

--- a/src/components/molecules/IngredientItem.vue
+++ b/src/components/molecules/IngredientItem.vue
@@ -48,7 +48,6 @@ export default Vue.extend({
       this.$emit("on-up-item");
     },
     onDownItem(): void {
-      console.log("on-down-item");
       this.$emit("on-down-item");
     }
   }

--- a/src/components/molecules/MemoItem.vue
+++ b/src/components/molecules/MemoItem.vue
@@ -1,19 +1,24 @@
 <template lang="pug">
   .MemoItem
-    //- move-icon
     div.flex
+      .wrap-icons.flex
+        i.move-icon(v-if="!isFirst")
+          up-icon(@click="onUpItem")
+        i.move-icon(v-if="!isLast")
+          down-icon(@click="onDownItem")
       span.index {{index+1}}.
-      .flex.flex-middle
+      .wrap-forms.flex
         app-textarea.description(
           placeholder="じゃがいもの下茹では電子レンジで代用できます"
           v-model="memo.description"
           rowNum=3
         )
-        i.icon(v-if="!isFirstItem")
+      i.icon(v-if="!isFirst")
           close-icon(@click="onDeleteItem")
 </template>
 <script lang="ts">
-import MoveIcon from "../../assets/icons/Orion_copy.svg";
+import UpIcon from "../../assets/icons/Orion_arrow_up.svg";
+import DownIcon from "../../assets/icons/Orion_arrow_down.svg";
 import CloseIcon from "../../assets/icons/Orion_close.svg";
 import AppTextarea from "../atoms/AppTextarea.vue";
 import Vue, { PropType } from "vue";
@@ -27,27 +32,30 @@ type Data = {
 
 export default Vue.extend({
   components: {
-    MoveIcon,
+    UpIcon,
+    DownIcon,
     CloseIcon,
     AppTextarea
   },
   props: {
     memo: Object as PropType<Memo>,
-    index: Number
-  },
-  data(): Data {
-    return {
-      memoItem: this.memo
-    };
+    index: Number,
+    isLast: Boolean
   },
   computed: {
-    isFirstItem(): boolean {
+    isFirst(): boolean {
       return this.index === 0;
     }
   },
   methods: {
     onDeleteItem(): void {
       this.$emit("on-delete-item");
+    },
+    onUpItem(): void {
+      this.$emit("on-up-item");
+    },
+    onDownItem(): void {
+      this.$emit("on-down-item");
     }
   }
 });
@@ -55,9 +63,24 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .MemoItem {
   width: 100%;
-  .description {
-    width: 265px;
-    margin-left: 10px;
+  .wrap-icons {
+    width: 31px;
+  }
+  .index {
+    width: 15px;
+    font-size: 12px;
+  }
+  .wrap-forms {
+    width: calc(100% - 70px);
+    textarea {
+      width: 100%;
+    }
+  }
+  .move-icon {
+    svg {
+      width: 14px;
+      height: 20px;
+    }
   }
 }
 </style>

--- a/src/components/molecules/StepItem.vue
+++ b/src/components/molecules/StepItem.vue
@@ -1,19 +1,24 @@
 <template lang="pug">
   .StepItem
-    //- move-icon
     div.flex
-      span.index {{index+1}}.
-      .flex.flex-middle
-        app-textarea.description(
+      .wrap-icons.flex
+        i.move-icon(v-if="!isFirst")
+          up-icon(@click="onUpItem")
+        i.move-icon(v-if="!isLast")
+          down-icon(@click="onDownItem")
+      .index {{index+1}}.
+      .wrap-forms.flex
+        app-textarea(
           placeholder="じゃがいもの皮をむき、一口大に切る"
           v-model="step.description"
           rowNum=2
         )
-        i.icon(v-if="!isFirstItem")
+      i.icon(v-if="!isFirst")
           close-icon(@click="onDeleteItem")
 </template>
 <script lang="ts">
-import MoveIcon from "../../assets/icons/Orion_copy.svg";
+import UpIcon from "../../assets/icons/Orion_arrow_up.svg";
+import DownIcon from "../../assets/icons/Orion_arrow_down.svg";
 import CloseIcon from "../../assets/icons/Orion_close.svg";
 import AppTextarea from "../atoms/AppTextarea.vue";
 import Vue, { PropType } from "vue";
@@ -21,33 +26,32 @@ export type Step = {
   description: string;
 };
 
-type Data = {
-  stepItem: Step;
-};
-
 export default Vue.extend({
   components: {
-    MoveIcon,
+    UpIcon,
+    DownIcon,
     CloseIcon,
     AppTextarea
   },
   props: {
     step: Object as PropType<Step>,
-    index: Number
-  },
-  data(): Data {
-    return {
-      stepItem: this.step
-    };
+    index: Number,
+    isLast: Boolean
   },
   computed: {
-    isFirstItem(): boolean {
+    isFirst(): boolean {
       return this.index === 0;
     }
   },
   methods: {
     onDeleteItem(): void {
       this.$emit("on-delete-item");
+    },
+    onUpItem(): void {
+      this.$emit("on-up-item");
+    },
+    onDownItem(): void {
+      this.$emit("on-down-item");
     }
   }
 });
@@ -55,9 +59,24 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .StepItem {
   width: 100%;
-  .description {
-    width: 265px;
-    margin-left: 10px;
+  .wrap-icons {
+    width: 31px;
+  }
+  .index {
+    width: 15px;
+    font-size: 12px;
+  }
+  .wrap-forms {
+    width: calc(100% - 70px);
+    textarea {
+      width: 100%;
+    }
+  }
+  .move-icon {
+    svg {
+      width: 14px;
+      height: 20px;
+    }
   }
 }
 </style>

--- a/src/components/organisms/CopyText.vue
+++ b/src/components/organisms/CopyText.vue
@@ -71,7 +71,7 @@ export default Vue.extend({
       );
     },
     formattedServingFor(): string {
-      return this.servingFor ? `（${this.servingFor})` : "";
+      return this.servingFor ? `(${this.servingFor})` : "";
     },
     formattedTitle(): string {
       return this.recipe.title ? `【${this.recipe.title}】` : "";

--- a/src/components/organisms/HashTagList.vue
+++ b/src/components/organisms/HashTagList.vue
@@ -52,9 +52,9 @@ export default Vue.extend({
 </script>
 <style lang="scss" scoped>
 .HashTagList {
-  width: 217px;
+  width: calc(100% - 31px);
+  margin-left: auto;
   .hash-tag-list {
-    width: 217px;
     li + li {
       margin-top: 5px;
     }

--- a/src/components/organisms/IngredientList.vue
+++ b/src/components/organisms/IngredientList.vue
@@ -63,14 +63,13 @@ export default Vue.extend({
       this.$emit("on-change-ingredient-list", this.ingredientItems);
     },
     upListItem(index: number): void {
-      this.$emit("on-up-ingredient-list", {
+      this.$emit("on-up-list", {
         item: "ingredients",
         index: index
       });
     },
     downListItem(index: number): void {
-      console.log("on-down-ingredient-list");
-      this.$emit("on-down-ingredient-list", {
+      this.$emit("on-down-list", {
         item: "ingredients",
         index: index
       });

--- a/src/components/organisms/IngredientList.vue
+++ b/src/components/organisms/IngredientList.vue
@@ -12,8 +12,11 @@
         ingredient-item(
           :ingredient="ingredient"
           :index="index"
+          :isLast="isLast(index)"
           @on-change-ingredient-item="onChangeIngredientList($event, index)"
           @on-delete-item="deleteListItem(index)"
+          @on-up-item="upListItem(index)"
+          @on-down-item="downListItem(index)"
         )
     .icon
       add-icon(@click="addListItem")
@@ -52,9 +55,25 @@ export default Vue.extend({
     };
   },
   methods: {
+    isLast(index: number): boolean {
+      return this.ingredients.length - 1 === index;
+    },
     onChangeIngredientList(ingredientItem: Ingredient, index: number): void {
       this.ingredientItems[index] = ingredientItem;
       this.$emit("on-change-ingredient-list", this.ingredientItems);
+    },
+    upListItem(index: number): void {
+      this.$emit("on-up-ingredient-list", {
+        item: "ingredients",
+        index: index
+      });
+    },
+    downListItem(index: number): void {
+      console.log("on-down-ingredient-list");
+      this.$emit("on-down-ingredient-list", {
+        item: "ingredients",
+        index: index
+      });
     },
     onChangeServingFor(servingFor: string): void {
       this.$emit("on-change-serving-for", servingFor);

--- a/src/components/organisms/MemoList.vue
+++ b/src/components/organisms/MemoList.vue
@@ -7,8 +7,11 @@
         memo-item(
           :memo="memo"
           :index="index"
+          :isLast="isLast(index)"
           @on-change-memo-item="onChangeMemoList($event, index)"
           @on-delete-item="deleteListItem(index)"
+          @on-up-item="upListItem(index)"
+          @on-down-item="downListItem(index)"
         )
     .icon
       add-icon(@click="addListItem")
@@ -19,10 +22,6 @@ import MemoItem from "../molecules/MemoItem.vue";
 import AddIcon from "../../assets/icons/Orion_add-circle.svg";
 import { Memo } from "../../components/molecules/MemoItem.vue";
 import Vue, { PropType } from "vue";
-
-type Data = {
-  memoItems: Array<Memo>;
-};
 
 export default Vue.extend({
   components: {
@@ -36,15 +35,25 @@ export default Vue.extend({
       default: () => []
     }
   },
-  data(): Data {
-    return {
-      memoItems: this.memos
-    };
-  },
   methods: {
+    isLast(index: number): boolean {
+      return this.memos.length - 1 === index;
+    },
     onChangeMemoList(memoItem: Memo, index: number): void {
       this.memoItems[index] = memoItem;
       this.$emit("on-change-memo-list", this.memoItems);
+    },
+    upListItem(index: number): void {
+      this.$emit("on-up-list", {
+        item: "memos",
+        index: index
+      });
+    },
+    downListItem(index: number): void {
+      this.$emit("on-down-list", {
+        item: "memos",
+        index: index
+      });
     },
     deleteListItem(index: number): void {
       this.$emit("delete-list-item", { item: "memos", index: index });

--- a/src/components/organisms/StepList.vue
+++ b/src/components/organisms/StepList.vue
@@ -7,8 +7,11 @@
         step-item(
           :step="step"
           :index="index"
+          :isLast="isLast(index)"
           @on-change-step-item="onChangeStepList($event, index)"
           @on-delete-item="deleteListItem(index)"
+          @on-up-item="upListItem(index)"
+          @on-down-item="downListItem(index)"
         )
     .icon
       add-icon(@click="addListItem")
@@ -41,9 +44,24 @@ export default Vue.extend({
     };
   },
   methods: {
+    isLast(index: number): boolean {
+      return this.steps.length - 1 === index;
+    },
     onChangeStepList(stepItem: Step, index: number): void {
       this.stepItems[index] = stepItem;
       this.$emit("on-change-step-list", this.stepItems);
+    },
+    upListItem(index: number): void {
+      this.$emit("on-up-list", {
+        item: "steps",
+        index: index
+      });
+    },
+    downListItem(index: number): void {
+      this.$emit("on-down-list", {
+        item: "steps",
+        index: index
+      });
     },
     deleteListItem(index: number): void {
       this.$emit("delete-list-item", { item: "steps", index: index });

--- a/src/pages/recipes/index.vue
+++ b/src/pages/recipes/index.vue
@@ -12,8 +12,8 @@
         @on-change-ingredient-list="onChangeIngredientList"
         @on-change-serving-for="onChangeServingFor",
         @delete-list-item="deleteListItem"
-        @on-up-ingredient-list="upListItem"
-        @on-down-ingredient-list="downListItem"
+        @on-up-list="upListItem"
+        @on-down-list="downListItem"
         @add-list-item="addListItem"
       )
       step-list.step-list(
@@ -21,12 +21,16 @@
         @on-change-step-list="onChangeStepList"
         @delete-list-item="deleteListItem"
         @add-list-item="addListItem"
+        @on-up-list="upListItem"
+        @on-down-list="downListItem"
         )
       memo-list.memo-list(
         :memos="memos"
         @on-change-memo-list="onChangeMemoList"
         @delete-list-item="deleteListItem"
         @add-list-item="addListItem"
+        @on-up-list="upListItem"
+        @on-down-list="downListItem"
       )
       hash-tag-list.hash-tag-list(
         :hashtags="hashtags"
@@ -137,7 +141,6 @@ export default Vue.extend({
       }
     },
     downListItem({ item, index }: { item: string; index: number }): void {
-      console.log(item, index);
       if (item === "ingredients") {
         this.ingredients.ingredientsList.splice(
           index,
@@ -145,7 +148,6 @@ export default Vue.extend({
           this.ingredients.ingredientsList[index + 1],
           this.ingredients.ingredientsList[index]
         );
-        this.ingredients.splice();
       } else {
         const array = this[item];
         array.splice(index, 2, array[index + 1], array[index]);

--- a/src/pages/recipes/index.vue
+++ b/src/pages/recipes/index.vue
@@ -12,6 +12,8 @@
         @on-change-ingredient-list="onChangeIngredientList"
         @on-change-serving-for="onChangeServingFor",
         @delete-list-item="deleteListItem"
+        @on-up-ingredient-list="upListItem"
+        @on-down-ingredient-list="downListItem"
         @add-list-item="addListItem"
       )
       step-list.step-list(
@@ -120,6 +122,34 @@ export default Vue.extend({
     },
     onChangeMemoList(memoList: Memo[]): void {
       this.memos = memoList;
+    },
+    upListItem({ item, index }: { item: string; index: number }): void {
+      if (item === "ingredients") {
+        this.ingredients.ingredientsList.splice(
+          index - 1,
+          2,
+          this.ingredients.ingredientsList[index],
+          this.ingredients.ingredientsList[index - 1]
+        );
+      } else {
+        const array = this[item];
+        array.splice(index - 1, 2, array[index], array[index - 1]);
+      }
+    },
+    downListItem({ item, index }: { item: string; index: number }): void {
+      console.log(item, index);
+      if (item === "ingredients") {
+        this.ingredients.ingredientsList.splice(
+          index,
+          2,
+          this.ingredients.ingredientsList[index + 1],
+          this.ingredients.ingredientsList[index]
+        );
+        this.ingredients.splice();
+      } else {
+        const array = this[item];
+        array.splice(index, 2, array[index + 1], array[index]);
+      }
     },
     deleteListItem({ item, index }: { item: string; index: number }): void {
       if (!confirm("削除してよろしいですか？")) return;


### PR DESCRIPTION
# 関連するIssue番号
- close #74 

# 変更目的
- インタビューで、材料や手順の前後入れ替えをしたいという意見が出た
- 自分が使う中でも、材料や手順を抜かしたときなどに既に入力した内容を一度削除して書き直すのは不便だと感じた

# 変更内容
- 手順、材料、備考に前後入れ替えボタン追加
  - 一番上、下の要素には、上移動、下移動のボタンを表示しないようにした
- 対応してコピー文章も変更

# UIの変更点

|変更前|変更後|
| --- | --- |
|<img width="495" alt="スクリーンショット 2020-04-21 23 30 10" src="https://user-images.githubusercontent.com/34161352/79878414-5a7e3400-8428-11ea-88ab-22844135a6ff.png">|<img width="377" alt="スクリーンショット 2020-04-21 23 30 19" src="https://user-images.githubusercontent.com/34161352/79878445-623dd880-8428-11ea-8d74-29cc478c422e.png">|

# 影響範囲

# 動作要件

# 補足
