### PR TITLE
コピー用の文章のline-heightを調整

### DIFF
--- a/src/components/organisms/CopyText.vue
+++ b/src/components/organisms/CopyText.vue
@@ -162,6 +162,7 @@ export default Vue.extend({
   width: 100%;
   border-top: 1px dashed gray;
   font-size: $small;
+  line-height: 1.2rem;
 
   .message-wrap {
     margin-top: 8px;


### PR DESCRIPTION
# 関連するIssue番号
- close #81

# 変更目的
- コピー用の文章の高さが小さすぎて文字が読みづらい
- インスタ投稿時の文章がイメージしづらい
# 変更内容
line-heightを変更。インスタの値が分からなかったので目視で近づけた。
# UIの変更点

|変更前|変更後|
| --- | --- |
|<img width="370" alt="スクリーンショット 2020-04-22 0 01 46" src="https://user-images.githubusercontent.com/34161352/79882511-b13a3c80-842d-11ea-9f30-bda759202b75.png">|<img width="379" alt="スクリーンショット 2020-04-22 0 00 44" src="https://user-images.githubusercontent.com/34161352/79882473-a2538a00-842d-11ea-856b-c492c129e763.png">|
