### PR TITLE
食材の単位を選択できるようにする

### DIFF
--- a/src/assets/css/common.scss
+++ b/src/assets/css/common.scss
@@ -85,6 +85,24 @@ a {
   -webkit-transition: 0.3s ease-in-out;
   transition: 0.3s ease-in-out;
 }
+
+// 並び替え・削除ボタンのcss
+
+.wrap-button {
+  width: 100%;
+  margin-top: 15px;
+  color: gray;
+  span {
+    padding: 5px 8px;
+    border: 1px solid gray;
+    border-radius: 3px;
+    cursor: pointer;
+  }
+  span + span {
+    margin-left: 15px;
+  }
+}
+
 .icon {
   width: 24px;
   height: 24px;
@@ -99,7 +117,7 @@ svg {
   svg {
     circle,
     path {
-      stroke: #078080;
+      stroke: gray;
       stroke-width: 3px;
     }
   }

--- a/src/assets/css/common.scss
+++ b/src/assets/css/common.scss
@@ -70,6 +70,23 @@ a {
   transition: 0.2s ease-in-out;
 }
 
+// placeholderの色変更
+@mixin placeholder() {
+  &::placeholder {
+    color: #c0c0c0;
+  }
+
+  // IE
+  &:-ms-input-placeholder {
+    color: #c0c0c0;
+  }
+
+  // Edge
+  &::-ms-input-placeholder {
+    color: #c0c0c0;
+  }
+}
+
 /*buttons*/
 .button {
   display: inline-block;

--- a/src/components/atoms/AppDatalist.vue
+++ b/src/components/atoms/AppDatalist.vue
@@ -1,21 +1,23 @@
 <template lang="pug">
-    .AppDatalist
-      div
-        .modal(
-          v-if="isOptionListShow"
-          @click="closeOptionList"
-        )
-        input.text-input(
-          :type="type"
-          :placeholder="placeholder"
-          v-model="text"
-          @focus="openOptionList"
-        )
-        .options(v-if="isOptionListShow")
-          p(
-            v-for="option in optionList"
-            @click="selectOption(option)"
-            ) {{option}}
+  .AppDatalist
+    div
+      .modal(
+        v-if="isOptionListShow"
+        @click="closeOptionList"
+      )
+      input.text-input(
+        :type="type"
+        :placeholder="placeholder"
+        v-model="text"
+        @focus="openOptionList"
+        ref="inputWithOption"
+        autocomplete="off"
+      )
+      .options(v-if="isOptionListShow")
+        p(
+          v-for="option in optionList"
+          @click="selectOption(option)"
+          ) {{option}}
 </template>
 <script lang="ts">
 import Vue from "vue";
@@ -33,7 +35,7 @@ export default Vue.extend({
   data(): Data {
     return {
       searchWord: this.value,
-      optionList: ["g", "ml", "l", "個", "本", "少々"],
+      optionList: ["g", "ml", "L", "cm", "個", "本"],
       isOptionListShow: false
     };
   },
@@ -57,6 +59,7 @@ export default Vue.extend({
   methods: {
     openOptionList(): void {
       this.isOptionListShow = true;
+      this.$nextTick(() => this.$refs.inputWithOption.focus());
     },
     closeOptionList(): void {
       this.isOptionListShow = false;
@@ -80,6 +83,7 @@ export default Vue.extend({
     padding: 3px 8px;
     border-radius: 3px;
     position: relative;
+    @include placeholder();
   }
   .modal {
     display: flex;
@@ -92,14 +96,14 @@ export default Vue.extend({
   }
   .options {
     position: absolute;
-    z-index: 3;
+    z-index: 5;
     background: #fffffe;
     font-size: $small;
     line-height: $small;
     padding: 3px 8px;
     border-radius: 2px;
     p {
-      padding: 7px 3px;
+      padding: 10px 3px;
     }
     p + p {
       border-top: 1px solid #f5f5f5;

--- a/src/components/atoms/AppDatalist.vue
+++ b/src/components/atoms/AppDatalist.vue
@@ -1,6 +1,10 @@
 <template lang="pug">
     .AppDatalist
       div
+        .modal(
+          v-if="isOptionListShow"
+          @click="closeOptionList"
+        )
         input.text-input(
           :type="type"
           :placeholder="placeholder"
@@ -9,7 +13,7 @@
         )
         .options(v-if="isOptionListShow")
           p(
-            v-for="option in filteredOptionList"
+            v-for="option in optionList"
             @click="selectOption(option)"
             ) {{option}}
 </template>
@@ -25,10 +29,6 @@ export default Vue.extend({
     type: String,
     placeholder: String,
     value: String
-    // keywords: {
-    //   type: Boolean,
-    //   default: false
-    // }
   },
   data(): Data {
     return {
@@ -45,13 +45,14 @@ export default Vue.extend({
       set(value: string): void {
         this.$emit("input", value);
       }
-    },
-    filteredOptionList(): string[] | [] {
-      if (!this.searchWord) return this.optionList;
-      return this.optionList.filter(item => {
-        return item.includes(this.searchWord);
-      });
     }
+    // optionsの数が少ないので、inputの値での絞り込みは一旦なし
+    // filteredOptionList(): string[] | [] {
+    //   if (!this.searchWord) return this.optionList;
+    //   return this.optionList.filter(item => {
+    //     return item.includes(this.searchWord);
+    //   });
+    // }
   },
   methods: {
     openOptionList(): void {
@@ -72,19 +73,37 @@ export default Vue.extend({
   width: 100%;
   .text-input {
     width: 100%;
+    z-index: 3;
     background: #fffffe;
     font-size: $small;
     line-height: $small;
     padding: 3px 8px;
     border-radius: 3px;
+    position: relative;
   }
-  datalist option {
+  .modal {
+    display: flex;
+    position: fixed;
+    z-index: 2;
+    top: 0;
+    left: 0;
     width: 100%;
+    height: 100%;
+  }
+  .options {
+    position: absolute;
+    z-index: 3;
     background: #fffffe;
     font-size: $small;
     line-height: $small;
     padding: 3px 8px;
-    border-radius: 3px;
+    border-radius: 2px;
+    p {
+      padding: 7px 3px;
+    }
+    p + p {
+      border-top: 1px solid #f5f5f5;
+    }
   }
 }
 </style>

--- a/src/components/atoms/AppDatalist.vue
+++ b/src/components/atoms/AppDatalist.vue
@@ -1,0 +1,90 @@
+<template lang="pug">
+    .AppDatalist
+      div
+        input.text-input(
+          :type="type"
+          :placeholder="placeholder"
+          v-model="text"
+          @focus="openOptionList"
+        )
+        .options(v-if="isOptionListShow")
+          p(
+            v-for="option in filteredOptionList"
+            @click="selectOption(option)"
+            ) {{option}}
+</template>
+<script lang="ts">
+import Vue from "vue";
+type Data = {
+  searchWord: string;
+  optionList: string[];
+  isOptionListShow: boolean;
+};
+export default Vue.extend({
+  props: {
+    type: String,
+    placeholder: String,
+    value: String
+    // keywords: {
+    //   type: Boolean,
+    //   default: false
+    // }
+  },
+  data(): Data {
+    return {
+      searchWord: this.value,
+      optionList: ["g", "ml", "l", "個", "本", "少々"],
+      isOptionListShow: false
+    };
+  },
+  computed: {
+    text: {
+      get(): string {
+        return this.value;
+      },
+      set(value: string): void {
+        this.$emit("input", value);
+      }
+    },
+    filteredOptionList(): string[] | [] {
+      if (!this.searchWord) return this.optionList;
+      return this.optionList.filter(item => {
+        return item.includes(this.searchWord);
+      });
+    }
+  },
+  methods: {
+    openOptionList(): void {
+      this.isOptionListShow = true;
+    },
+    closeOptionList(): void {
+      this.isOptionListShow = false;
+    },
+    selectOption(option: string): void {
+      this.$emit("input", option);
+      this.closeOptionList();
+    }
+  }
+});
+</script>
+<style lang="scss" scoped>
+.AppDatalist {
+  width: 100%;
+  .text-input {
+    width: 100%;
+    background: #fffffe;
+    font-size: $small;
+    line-height: $small;
+    padding: 3px 8px;
+    border-radius: 3px;
+  }
+  datalist option {
+    width: 100%;
+    background: #fffffe;
+    font-size: $small;
+    line-height: $small;
+    padding: 3px 8px;
+    border-radius: 3px;
+  }
+}
+</style>

--- a/src/components/atoms/AppForm.vue
+++ b/src/components/atoms/AppForm.vue
@@ -1,11 +1,11 @@
 <template lang="pug">
-    .AppForm
-      input.text-input(
-        :type="type"
-        :placeholder="placeholder"
-        v-model="text"
-        :disabled="disabled"
-      )
+  .AppForm
+    input.text-input(
+      :type="type"
+      :placeholder="placeholder"
+      v-model="text"
+      :disabled="disabled"
+    )
 </template>
 <script lang="ts">
 import Vue from "vue";
@@ -50,6 +50,7 @@ export default Vue.extend({
     line-height: $small;
     padding: 3px 8px;
     border-radius: 3px;
+    @include placeholder();
   }
 }
 </style>

--- a/src/components/atoms/AppKeyboardOption.vue
+++ b/src/components/atoms/AppKeyboardOption.vue
@@ -96,6 +96,9 @@ export default Vue.extend({
     height: 100%;
     // background-color: #f45d48;
   }
+  .text-input {
+    @include placeholder();
+  }
   .keyboard-option {
     position: fixed;
     width: 100%;

--- a/src/components/atoms/AppKeyboardOption.vue
+++ b/src/components/atoms/AppKeyboardOption.vue
@@ -1,0 +1,119 @@
+<template lang="pug">
+  .AppFormWithKeyboardOption
+    div
+      .modal(
+        v-if="isOptionListShow"
+        @click="closeOptionList"
+      )
+      input.text-input(
+        :type="type"
+        :placeholder="placeholder"
+        v-model="text"
+        @focus="openOptionList"
+        ref="inputWithKeyboardOption"
+        autocomplete="off"
+      )
+      .keyboard-option(v-if="isOptionListShow")
+        .flex.space-between
+          p(
+            v-for="option in optionList"
+            @click="selectOption(option)"
+          ) {{option}}
+</template>
+<script lang="ts">
+import Vue from "vue";
+type Data = {
+  searchWord: string;
+  optionList: string[];
+  isOptionListShow: boolean;
+};
+export default Vue.extend({
+  props: {
+    type: String,
+    placeholder: String,
+    value: String
+  },
+  data(): Data {
+    return {
+      searchWord: this.value,
+      optionList: ["大さじ", "小さじ", "約", "各", "少々"],
+      isOptionListShow: false
+    };
+  },
+  computed: {
+    text: {
+      get(): string {
+        return this.value;
+      },
+      set(value: string): void {
+        this.$emit("input", value);
+      }
+    }
+    // optionsの数が少ないので、inputの値での絞り込みは一旦なし
+    // filteredOptionList(): string[] | [] {
+    //   if (!this.searchWord) return this.optionList;
+    //   return this.optionList.filter(item => {
+    //     return item.includes(this.searchWord);
+    //   });
+    // }
+  },
+  methods: {
+    openOptionList(): void {
+      this.isOptionListShow = true;
+      this.$nextTick(() => this.$refs.inputWithKeyboardOption.focus());
+    },
+    closeOptionList(): void {
+      this.isOptionListShow = false;
+    },
+    selectOption(option: string): void {
+      this.$emit("input", option + this.text);
+      this.closeOptionList();
+      this.$nextTick(() => this.$refs.inputWithKeyboardOption.focus());
+    }
+  }
+});
+</script>
+<style lang="scss" scoped>
+.AppFormWithKeyboardOption {
+  width: 100%;
+  .text-input {
+    width: 100%;
+    z-index: 3;
+    background: #fffffe;
+    font-size: $small;
+    line-height: $small;
+    padding: 3px 8px;
+    border-radius: 3px;
+    position: relative;
+  }
+  .modal {
+    display: flex;
+    position: fixed;
+    z-index: 2;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    // background-color: #f45d48;
+  }
+  .keyboard-option {
+    position: fixed;
+    width: 100%;
+    bottom: 0;
+    left: 0;
+    z-index: 5;
+    padding: 10px;
+    background-color: #f3f3f3;
+    p {
+      width: calc(100% / 4);
+      color: gray;
+      font-weight: bold;
+      text-align: center;
+      padding: 3px;
+    }
+    p + p {
+      border-left: 1px solid #c0c0c0;
+    }
+  }
+}
+</style>

--- a/src/components/atoms/AppTextarea.vue
+++ b/src/components/atoms/AppTextarea.vue
@@ -48,6 +48,7 @@ export default Vue.extend({
     padding: 3px 8px;
     border-radius: 3px;
     resize: none;
+    @include placeholder();
   }
   .textarea-2 {
     height: calc(1.4rem * 2);

--- a/src/components/molecules/HashTagItem.vue
+++ b/src/components/molecules/HashTagItem.vue
@@ -47,7 +47,6 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .HashTagItem {
   .title {
-    width: calc(100% - 38px);
     margin-left: 5px;
   }
 }

--- a/src/components/molecules/IngredientItem.vue
+++ b/src/components/molecules/IngredientItem.vue
@@ -4,7 +4,7 @@
       .wrap-forms.flex.flex-middle
         app-form.name(type="text" placeholder="じゃがいも" v-model="ingredient.name")
         app-form.amount(type="text" placeholder="2" v-model="ingredient.amount")
-        app-form.unit(type="text" placeholder="個" v-model="ingredient.unit")
+        app-datalist.unit(type="text" placeholder="個" v-model="ingredient.unit")
     div.flex.flex-middle(v-else)
       .icon.wrap-icons.flex
         i.move-icon(v-show="!isFirst")
@@ -23,6 +23,7 @@ import UpIcon from "../../assets/icons/Orion_arrow_up.svg";
 import DownIcon from "../../assets/icons/Orion_arrow_down.svg";
 import CloseIcon from "../../assets/icons/Orion_close.svg";
 import AppForm from "../atoms/AppForm.vue";
+import AppDatalist from "../atoms/AppDatalist.vue";
 import Vue, { PropType } from "vue";
 export type Ingredient = {
   name: string;
@@ -35,7 +36,8 @@ export default Vue.extend({
     UpIcon,
     DownIcon,
     CloseIcon,
-    AppForm
+    AppForm,
+    AppDatalist
   },
   props: {
     ingredient: Object as PropType<Ingredient>,

--- a/src/components/molecules/IngredientItem.vue
+++ b/src/components/molecules/IngredientItem.vue
@@ -3,7 +3,7 @@
     div(v-if="isEdit")
       .wrap-forms.flex.flex-middle
         app-form.name(type="text" placeholder="じゃがいも" v-model="ingredient.name")
-        app-form.amount(type="text" placeholder="2" v-model="ingredient.amount")
+        app-keyboard-option.amount(type="text" placeholder="2" v-model="ingredient.amount")
         app-datalist.unit(type="text" placeholder="個" v-model="ingredient.unit")
     div.flex.flex-middle(v-else)
       .icon.wrap-icons.flex
@@ -24,20 +24,21 @@ import DownIcon from "../../assets/icons/Orion_arrow_down.svg";
 import CloseIcon from "../../assets/icons/Orion_close.svg";
 import AppForm from "../atoms/AppForm.vue";
 import AppDatalist from "../atoms/AppDatalist.vue";
+import AppKeyboardOption from "../atoms/AppKeyboardOption.vue";
 import Vue, { PropType } from "vue";
 export type Ingredient = {
   name: string;
   amount: string;
   unit: string;
 };
-
 export default Vue.extend({
   components: {
     UpIcon,
     DownIcon,
     CloseIcon,
     AppForm,
-    AppDatalist
+    AppDatalist,
+    AppKeyboardOption
   },
   props: {
     ingredient: Object as PropType<Ingredient>,
@@ -74,11 +75,11 @@ export default Vue.extend({
       width: 60%;
     }
     .amount {
-      width: 19%;
+      width: 25%;
       margin-left: 1%;
     }
     .unit {
-      width: 19%;
+      width: 13%;
       margin-left: 1%;
     }
   }

--- a/src/components/molecules/IngredientItem.vue
+++ b/src/components/molecules/IngredientItem.vue
@@ -1,14 +1,20 @@
 <template lang="pug">
   .IngredientItem
-    div.flex.flex-middle
-      .icon.wrap-icons.flex
-        i.move-icon(v-if="!isFirst")
-          up-icon(@click="onUpItem")
-        i.move-icon(v-if="!isLast")
-          down-icon(@click="onDownItem")
-      .wrap-forms.flex
+    div(v-if="isEdit")
+      .wrap-forms.flex.flex-middle
         app-form.name(type="text" placeholder="じゃがいも" v-model="ingredient.name")
-        app-form.amount(type="text" placeholder="2つ" v-model="ingredient.amount")
+        app-form.amount(type="text" placeholder="2" v-model="ingredient.amount")
+        app-form.unit(type="text" placeholder="個" v-model="ingredient.unit")
+    div.flex.flex-middle(v-else)
+      .icon.wrap-icons.flex
+        i.move-icon(v-show="!isFirst")
+          up-icon(@click="onUpItem")
+        i.move-icon(v-show="!isLast")
+          down-icon(@click="onDownItem")
+      .wrap-texts.flex
+        p.name {{ingredient.name}}
+        p.amount {{ingredient.amount}}
+        p.unit {{ingredient.unit}}
       i.icon
         close-icon(@click="onDeleteItem")
 </template>
@@ -21,6 +27,7 @@ import Vue, { PropType } from "vue";
 export type Ingredient = {
   name: string;
   amount: string;
+  unit: string;
 };
 
 export default Vue.extend({
@@ -33,7 +40,8 @@ export default Vue.extend({
   props: {
     ingredient: Object as PropType<Ingredient>,
     index: Number,
-    isLast: Boolean
+    isLast: Boolean,
+    isEdit: Boolean
   },
   computed: {
     isFirst(): boolean {
@@ -60,13 +68,30 @@ export default Vue.extend({
     width: 31px;
   }
   .wrap-forms {
-    width: calc(100% - 55px);
     .name {
-      width: 70%;
+      width: 60%;
     }
     .amount {
-      width: 30%;
-      margin-left: 7px;
+      width: 19%;
+      margin-left: 1%;
+    }
+    .unit {
+      width: 19%;
+      margin-left: 1%;
+    }
+  }
+  .wrap-texts {
+    width: calc(100% - 55px);
+    .name {
+      width: 60%;
+    }
+    .amount {
+      width: 19%;
+      margin-left: 1%;
+    }
+    .unit {
+      width: 19%;
+      margin-left: 1%;
     }
   }
   .move-icon {

--- a/src/components/molecules/MemoItem.vue
+++ b/src/components/molecules/MemoItem.vue
@@ -1,11 +1,6 @@
 <template lang="pug">
   .MemoItem
-    div.flex
-      .icon.wrap-icons.flex
-        i.move-icon(v-if="!isFirst")
-          up-icon(@click="onUpItem")
-        i.move-icon(v-if="!isLast")
-          down-icon(@click="onDownItem")
+    div.flex(v-if="isEdit")
       span.index {{index+1}}.
       .wrap-forms.flex
         app-textarea.description(
@@ -13,7 +8,16 @@
           v-model="memo.description"
           rowNum=3
         )
-      i.icon(v-if="!isFirst")
+    div.flex(v-else)
+      .icon.wrap-icons.flex
+        i.move-icon(v-show="!isFirst")
+          up-icon(@click="onUpItem")
+        i.move-icon(v-show="!isLast")
+          down-icon(@click="onDownItem")
+      span.index {{index+1}}.
+      .wrap-texts
+        p {{memo.description}}
+      i.icon(v-show="!isFirst")
           close-icon(@click="onDeleteItem")
 </template>
 <script lang="ts">
@@ -40,7 +44,8 @@ export default Vue.extend({
   props: {
     memo: Object as PropType<Memo>,
     index: Number,
-    isLast: Boolean
+    isLast: Boolean,
+    isEdit: Boolean
   },
   computed: {
     isFirst(): boolean {
@@ -63,23 +68,29 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .MemoItem {
   width: 100%;
-  .wrap-icons {
-    width: 31px;
-  }
   .index {
     width: 15px;
     font-size: 12px;
   }
   .wrap-forms {
-    width: calc(100% - 70px);
+    width: 100%;
     textarea {
       width: 100%;
     }
   }
-  .move-icon {
-    svg {
-      width: 14px;
-      height: 20px;
+  .wrap-texts {
+    width: calc(100% - 71px);
+    textarea {
+      width: 100%;
+    }
+  }
+  .wrap-icons {
+    width: 31px;
+    .move-icon {
+      svg {
+        width: 14px;
+        height: 20px;
+      }
     }
   }
 }

--- a/src/components/molecules/RecipeTitle.vue
+++ b/src/components/molecules/RecipeTitle.vue
@@ -64,12 +64,8 @@ export default Vue.extend({
     span {
       font-size: $default;
     }
-    .title {
-      max-width: calc(100% - 50px);
-    }
   }
   .description {
-    width: 290px;
     margin-top: 5px;
   }
 }

--- a/src/components/molecules/StepItem.vue
+++ b/src/components/molecules/StepItem.vue
@@ -1,19 +1,24 @@
 <template lang="pug">
   .StepItem
-    div.flex
+    div(v-if="isEdit")
+      .wrap-forms.flex
+        .index {{index+1}}.
+        .wrap-forms.flex
+          app-textarea(
+            placeholder="じゃがいもの皮をむき、一口大に切る"
+            v-model="step.description"
+            rowNum=2
+          )
+    div.flex(v-else)
       .icon.wrap-icons.flex
-        i.move-icon(v-if="!isFirst")
+        i.move-icon(v-show="!isFirst")
           up-icon(@click="onUpItem")
-        i.move-icon(v-if="!isLast")
+        i.move-icon(v-show="!isLast")
           down-icon(@click="onDownItem")
       .index {{index+1}}.
-      .wrap-forms.flex
-        app-textarea(
-          placeholder="じゃがいもの皮をむき、一口大に切る"
-          v-model="step.description"
-          rowNum=2
-        )
-      i.icon(v-if="!isFirst")
+      .wrap-texts
+        p {{step.description}}
+      i.icon(v-show="!isFirst")
           close-icon(@click="onDeleteItem")
 </template>
 <script lang="ts">
@@ -36,7 +41,8 @@ export default Vue.extend({
   props: {
     step: Object as PropType<Step>,
     index: Number,
-    isLast: Boolean
+    isLast: Boolean,
+    isEdit: Boolean
   },
   computed: {
     isFirst(): boolean {
@@ -59,23 +65,29 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .StepItem {
   width: 100%;
-  .wrap-icons {
-    width: 31px;
-  }
   .index {
     width: 15px;
     font-size: 12px;
   }
   .wrap-forms {
-    width: calc(100% - 70px);
+    width: 100%;
     textarea {
       width: 100%;
     }
   }
-  .move-icon {
-    svg {
-      width: 14px;
-      height: 20px;
+  .wrap-texts {
+    width: calc(100% - 71px);
+    textarea {
+      width: 100%;
+    }
+  }
+  .wrap-icons {
+    width: 31px;
+    .move-icon {
+      svg {
+        width: 14px;
+        height: 20px;
+      }
     }
   }
 }

--- a/src/components/organisms/CopyText.vue
+++ b/src/components/organisms/CopyText.vue
@@ -210,7 +210,7 @@ export default Vue.extend({
     padding: 10px 8px;
     border-radius: 3px;
     .default-message {
-      color: gray;
+      color: #c0c0c0;
     }
     p {
       margin: 2px;

--- a/src/components/organisms/CopyText.vue
+++ b/src/components/organisms/CopyText.vue
@@ -87,7 +87,8 @@ export default Vue.extend({
     formattedIngredientItem(): string {
       return this.ingredients.reduce(
         (accumulator, currentValue) =>
-          accumulator + `\r\n${currentValue.name}  ${currentValue.amount}`,
+          accumulator +
+          `\r\n${currentValue.name}  ${currentValue.amount}${currentValue.unit}`,
         ""
       );
     },

--- a/src/components/organisms/CopyText.vue
+++ b/src/components/organisms/CopyText.vue
@@ -169,8 +169,14 @@ export default Vue.extend({
     margin-left: auto;
     .copy-message {
       margin-left: 5px;
-      color: #078080;
+      color: #f45d3a;
       font-weight: bold;
+    }
+    svg {
+      path {
+        stroke: #f45d3a;
+        stroke-width: 8px;
+      }
     }
   }
   .tool-tip {

--- a/src/components/organisms/HashTagList.vue
+++ b/src/components/organisms/HashTagList.vue
@@ -8,8 +8,8 @@
           @on-change-hashtag-item="onChangeHashtagList($event, index)"
           @on-delete-item="deleteListItem(index)"
         )
-    .icon
-      add-icon(@click="addListItem")
+    .wrap-button.flex.flex-middle.content-center
+      span.add(@click="addListItem") ＋ハッシュタグを追加
 </template>
 <script lang="ts">
 import HashTagItem from "../molecules/HashTagItem.vue";
@@ -53,6 +53,7 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .HashTagList {
   width: calc(100% - 31px);
+  margin-top: 15px;
   margin-left: auto;
   .hash-tag-list {
     li + li {

--- a/src/components/organisms/HashTagList.vue
+++ b/src/components/organisms/HashTagList.vue
@@ -52,7 +52,6 @@ export default Vue.extend({
 </script>
 <style lang="scss" scoped>
 .HashTagList {
-  width: calc(100% - 31px);
   margin-top: 15px;
   margin-left: auto;
   .hash-tag-list {

--- a/src/components/organisms/IngredientList.vue
+++ b/src/components/organisms/IngredientList.vue
@@ -13,13 +13,19 @@
           :ingredient="ingredient"
           :index="index"
           :isLast="isLast(index)"
+          :isEdit="isEdit"
           @on-change-ingredient-item="onChangeIngredientList($event, index)"
           @on-delete-item="deleteListItem(index)"
           @on-up-item="upListItem(index)"
           @on-down-item="downListItem(index)"
         )
-    .icon
-      add-icon(@click="addListItem")
+    .wrap-button.flex.flex-middle.content-center(v-if="isEdit")
+      span.switch(@click="toggleEdit") ＋並び替え
+      span.add(@click="addListItem") ＋材料を追加
+    .wrap-button.flex.flex-middle.content-center(v-else)
+      span.switch(@click="toggleEdit") ＋並び替えを完了
+    //- .icon
+    //-   add-icon(@click="addListItem")
 </template>
 <script lang="ts">
 import AppSubTitle from "../atoms/AppSubTitle.vue";
@@ -30,6 +36,7 @@ import Vue, { PropType } from "vue";
 type Data = {
   ingredientItems: Array<Ingredient>;
   servingForItem: string;
+  isEdit: boolean;
 };
 
 export default Vue.extend({
@@ -51,12 +58,16 @@ export default Vue.extend({
   data(): Data {
     return {
       ingredientItems: this.ingredients,
-      servingForItem: this.servingFor
+      servingForItem: this.servingFor,
+      isEdit: true
     };
   },
   methods: {
     isLast(index: number): boolean {
       return this.ingredients.length - 1 === index;
+    },
+    toggleEdit() {
+      this.isEdit = !this.isEdit;
     },
     onChangeIngredientList(ingredientItem: Ingredient, index: number): void {
       this.ingredientItems[index] = ingredientItem;
@@ -90,15 +101,11 @@ export default Vue.extend({
 .IngredientList {
   width: 100%;
   .ingredient-list {
+    width: 100%;
     margin-top: 5px;
-    width: 316px;
     li + li {
       margin-top: 5px;
     }
-  }
-  .icon {
-    margin-left: auto;
-    margin-top: 10px;
   }
 }
 </style>

--- a/src/components/organisms/MemoList.vue
+++ b/src/components/organisms/MemoList.vue
@@ -8,13 +8,19 @@
           :memo="memo"
           :index="index"
           :isLast="isLast(index)"
+          :isEdit="isEdit"
           @on-change-memo-item="onChangeMemoList($event, index)"
           @on-delete-item="deleteListItem(index)"
           @on-up-item="upListItem(index)"
           @on-down-item="downListItem(index)"
         )
-    .icon
-      add-icon(@click="addListItem")
+    .wrap-button.flex.flex-middle.content-center(v-if="isEdit")
+      span.switch(@click="toggleEdit") ＋並び替え
+      span.add(@click="addListItem") ＋備考を追加
+    .wrap-button.flex.flex-middle.content-center(v-else)
+      span.switch(@click="toggleEdit") ＋並び替えを完了
+    //- .icon
+    //-   add-icon(@click="addListItem")
 </template>
 <script lang="ts">
 import AppSubTitle from "../atoms/AppSubTitle.vue";
@@ -22,6 +28,9 @@ import MemoItem from "../molecules/MemoItem.vue";
 import AddIcon from "../../assets/icons/Orion_add-circle.svg";
 import { Memo } from "../../components/molecules/MemoItem.vue";
 import Vue, { PropType } from "vue";
+type Data = {
+  isEdit: boolean;
+};
 
 export default Vue.extend({
   components: {
@@ -35,9 +44,17 @@ export default Vue.extend({
       default: () => []
     }
   },
+  data(): Data {
+    return {
+      isEdit: true
+    };
+  },
   methods: {
     isLast(index: number): boolean {
       return this.memos.length - 1 === index;
+    },
+    toggleEdit() {
+      this.isEdit = !this.isEdit;
     },
     onChangeMemoList(memoItem: Memo, index: number): void {
       this.memos[index] = memoItem;
@@ -67,6 +84,7 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .MemoList {
   width: 100%;
+  margin-top: 15px;
   .memo-list {
     margin-top: 5px;
     width: 316px;

--- a/src/components/organisms/StepList.vue
+++ b/src/components/organisms/StepList.vue
@@ -8,13 +8,17 @@
           :step="step"
           :index="index"
           :isLast="isLast(index)"
+          :isEdit="isEdit"
           @on-change-step-item="onChangeStepList($event, index)"
           @on-delete-item="deleteListItem(index)"
           @on-up-item="upListItem(index)"
           @on-down-item="downListItem(index)"
         )
-    .icon
-      add-icon(@click="addListItem")
+    .wrap-button.flex.flex-middle.content-center(v-if="isEdit")
+      span.switch(@click="toggleEdit") ＋並び替え
+      span.add(@click="addListItem") ＋手順を追加
+    .wrap-button.flex.flex-middle.content-center(v-else)
+      span.switch(@click="toggleEdit") ＋並び替えを完了
 </template>
 <script lang="ts">
 import AppSubTitle from "../atoms/AppSubTitle.vue";
@@ -24,6 +28,7 @@ import { Step } from "../../components/molecules/StepItem.vue";
 import Vue, { PropType } from "vue";
 type Data = {
   stepItems: Step[];
+  isEdit: boolean;
 };
 
 export default Vue.extend({
@@ -40,12 +45,16 @@ export default Vue.extend({
   },
   data(): Data {
     return {
-      stepItems: this.steps
+      stepItems: this.steps,
+      isEdit: true
     };
   },
   methods: {
     isLast(index: number): boolean {
       return this.steps.length - 1 === index;
+    },
+    toggleEdit() {
+      this.isEdit = !this.isEdit;
     },
     onChangeStepList(stepItem: Step, index: number): void {
       this.stepItems[index] = stepItem;
@@ -75,6 +84,7 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .StepList {
   width: 100%;
+  margin-top: 15px;
   .step-list {
     margin-top: 5px;
     li + li {

--- a/src/pages/recipes/index.vue
+++ b/src/pages/recipes/index.vue
@@ -167,7 +167,11 @@ export default Vue.extend({
     addListItem({ item }: { item: string }): void {
       switch (item) {
         case "ingredients":
-          this.ingredients.ingredientsList.push({ name: "", amount: "" });
+          this.ingredients.ingredientsList.push({
+            name: "",
+            amount: "",
+            unit: ""
+          });
           break;
         case "steps":
           this.steps.push({ description: "" });

--- a/src/pages/recipes/index.vue
+++ b/src/pages/recipes/index.vue
@@ -89,7 +89,8 @@ export default Vue.extend({
       ingredientsList: [
         {
           name: "",
-          amount: ""
+          amount: "",
+          unit: ""
         }
       ],
       servingFor: ""

--- a/src/pages/recipes/index.vue
+++ b/src/pages/recipes/index.vue
@@ -3,7 +3,7 @@
     .wrap
       .app-logo
         app-logo.logo
-        span あなたの味をだれかに届けよう
+        span あなたの味を届けよう
       recipe-title.recipe-title(
         :recipe="recipe"
         @on-change-recipe-title="onChangeRecipeTitle"
@@ -192,6 +192,7 @@ export default Vue.extend({
   font-size: $small;
   .app-logo {
     text-align: center;
+    color: gray;
     .logo {
       width: 316px;
       height: 46px;


### PR DESCRIPTION
# 関連するIssue番号
- close #93 

# 変更目的
- 食材の欄で、単位をプルダウンで入力できるようにする
- 単位は半角や記号が必要なものが多く、スマホではキーボードを切り替えて入力するのが面倒

# 変更内容
- 材料にunit(単位)カラムを追加
- 単位の入力で自由入力とドロップダウンを両立できるようにする
- 文章の入力ではキーボードの上部によく使う単語を補助的に表示
  - クリックするとその文字が入力され、カーソルはフォームに戻る
- 並び替えボタンを初期は非表示にする
  - 並び替えを押すと、文字は固定の代わりに入れ替えボタンが表示される
  - 完了を押すと元の入力ができる
  - 追加もデザインを合わせる
  - 追加ボタンが下部に表示されるようになったので、フォーム幅を調整

# UIの変更点

|変更前|変更後|
| --- | --- |
|<img width="461" alt="スクリーンショット 2020-05-24 17 18 02" src="https://user-images.githubusercontent.com/34161352/82749230-9ff49f00-9de2-11ea-9454-b03dc7327fb4.png">|<img width="411" alt="スクリーンショット 2020-05-24 17 18 21" src="https://user-images.githubusercontent.com/34161352/82749236-a97e0700-9de2-11ea-8e60-e4048b73f869.png">|

# 影響範囲

# 動作要件

# 補足