### PR TITLE
feature: 著作権表示の追加

### DIFF
--- a/src/assets/css/common.scss
+++ b/src/assets/css/common.scss
@@ -21,7 +21,7 @@ html {
 
 .wrap {
   width: 316px;
-  margin: 35px auto;
+  margin: 35px auto 0 auto;
 }
 
 /*flex-class*/

--- a/src/components/atoms/AppFooter.vue
+++ b/src/components/atoms/AppFooter.vue
@@ -1,0 +1,17 @@
+<template lang="pug">
+  .AppFooter
+    p.copyright ©2020 amakawa
+</template>
+<script lang="ts">
+import Vue from "vue";
+export default Vue.extend({});
+</script>
+<style lang="scss" scoped>
+.AppFooter {
+  width: 100%;
+  margin: 35px 0 15px 0;
+  text-align: center;
+  color: gray;
+  font-size: $mini;
+}
+</style>

--- a/src/components/molecules/HashTagItem.vue
+++ b/src/components/molecules/HashTagItem.vue
@@ -47,6 +47,7 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .HashTagItem {
   .title {
+    width: calc(100% - 38px);
     margin-left: 5px;
   }
 }

--- a/src/pages/recipes/index.vue
+++ b/src/pages/recipes/index.vue
@@ -48,6 +48,7 @@
         :memos="memos"
         :hashtags="hashtags"
       )
+      app-footer
 </template>
 
 <script lang="ts">
@@ -59,6 +60,7 @@ import StepList from "../../components/organisms/StepList.vue";
 import MemoList from "../../components/organisms/MemoList.vue";
 import CopyText from "../../components/organisms/CopyText.vue";
 import HashTagList from "../../components/organisms/HashTagList.vue";
+import AppFooter from "../../components/atoms/AppFooter.vue";
 import { Recipe } from "../../components/molecules/RecipeTitle.vue";
 import { Hashtag } from "../../components/molecules/HashTagItem.vue";
 import { Ingredient } from "../../components/molecules/IngredientItem.vue";
@@ -78,7 +80,8 @@ export default Vue.extend({
     StepList,
     MemoList,
     HashTagList,
-    CopyText
+    CopyText,
+    AppFooter
   },
   data: (): Data => ({
     recipe: {


### PR DESCRIPTION
# 関連するIssue番号
- close #85 

# 変更目的
- 著作権表示がなかった

# 変更内容
- 画面最下部に著作権表示を追加

# UIの変更点

|変更前|変更後|
| --- | --- |
|<img width="369" alt="スクリーンショット 2020-05-24 17 53 22" src="https://user-images.githubusercontent.com/34161352/82749929-9588d400-9de7-11ea-9f99-e04299ff5af7.png">|<img width="410" alt="スクリーンショット 2020-05-24 17 53 56" src="https://user-images.githubusercontent.com/34161352/82749935-9d487880-9de7-11ea-8fa3-9f430f57de49.png">|

# 影響範囲

# 動作要件

# 補足
