### PR TITLE
fix: $refsの型定義不足によるエラー解消

### DIFF
--- a/src/components/atoms/AppDatalist.vue
+++ b/src/components/atoms/AppDatalist.vue
@@ -10,7 +10,7 @@
         :placeholder="placeholder"
         v-model="text"
         @focus="openOptionList"
-        ref="inputWithOption"
+        id="inputWithOption"
         autocomplete="off"
       )
       .options(v-if="isOptionListShow")
@@ -59,7 +59,10 @@ export default Vue.extend({
   methods: {
     openOptionList(): void {
       this.isOptionListShow = true;
-      this.$nextTick(() => this.$refs.inputWithOption.focus());
+      const optionList: HTMLInputElement = document.getElementById(
+        "inputWithOption"
+      ) as HTMLInputElement;
+      this.$nextTick(() => optionList.focus());
     },
     closeOptionList(): void {
       this.isOptionListShow = false;

--- a/src/components/atoms/AppKeyboardOption.vue
+++ b/src/components/atoms/AppKeyboardOption.vue
@@ -10,7 +10,7 @@
         :placeholder="placeholder"
         v-model="text"
         @focus="openOptionList"
-        ref="inputWithKeyboardOption"
+        id="inputWithKeyboardOption"
         autocomplete="off"
       )
       .keyboard-option(v-if="isOptionListShow")
@@ -60,7 +60,10 @@ export default Vue.extend({
   methods: {
     openOptionList(): void {
       this.isOptionListShow = true;
-      this.$nextTick(() => this.$refs.inputWithKeyboardOption.focus());
+      const keyboardOption: HTMLInputElement = document.getElementById(
+        "inputWithKeyboardOption"
+      ) as HTMLInputElement;
+      this.$nextTick(() => keyboardOption.focus());
     },
     closeOptionList(): void {
       this.isOptionListShow = false;
@@ -68,7 +71,10 @@ export default Vue.extend({
     selectOption(option: string): void {
       this.$emit("input", option + this.text);
       this.closeOptionList();
-      this.$nextTick(() => this.$refs.inputWithKeyboardOption.focus());
+      const keyboardOption: HTMLInputElement = document.getElementById(
+        "inputWithKeyboardOption"
+      ) as HTMLInputElement;
+      this.$nextTick(() => keyboardOption.focus());
     }
   }
 });


### PR DESCRIPTION
# 関連するIssue番号
- close #95 

# バグ内容
$refsの型定義がされていないことによるエラー
<img width="771" alt="スクリーンショット 2020-05-30 10 54 22" src="https://user-images.githubusercontent.com/34161352/83316972-67cae180-a264-11ea-96e8-d1a21711100a.png">

$refsはDOM要素への参照を持つが、実行時によって内容が変わるので、事前に型指定ができない。しかし、Element要素を持っているので、HTMLやVueコンポーネントへの型キャストができる。
https://engineering.linecorp.com/ja/blog/vue-js-typescript-otoshidama/

# 修正内容
子コンポーネントへの指定ではなく$refsではいけない理由もなかったので、`getElementById`を使う方法に変更した。