### PR TITLE
fix: 分量と単位の指定をidからrefに戻して型指定

### DIFF
--- a/src/components/atoms/AppDatalist.vue
+++ b/src/components/atoms/AppDatalist.vue
@@ -10,7 +10,7 @@
         :placeholder="placeholder"
         v-model="text"
         @focus="openOptionList"
-        id="inputWithOption"
+        ref="inputWithOption"
         autocomplete="off"
       )
       .options(v-if="isOptionListShow")
@@ -21,6 +21,7 @@
 </template>
 <script lang="ts">
 import Vue from "vue";
+import { isHTMLElement } from "../../utils/types";
 type Data = {
   searchWord: string;
   optionList: string[];
@@ -59,9 +60,8 @@ export default Vue.extend({
   methods: {
     openOptionList(): void {
       this.isOptionListShow = true;
-      const optionList: HTMLInputElement = document.getElementById(
-        "inputWithOption"
-      ) as HTMLInputElement;
+      const optionList = this.$refs.inputWithOption;
+      if (!isHTMLElement(optionList)) return;
       this.$nextTick(() => optionList.focus());
     },
     closeOptionList(): void {

--- a/src/components/atoms/AppKeyboardOption.vue
+++ b/src/components/atoms/AppKeyboardOption.vue
@@ -10,7 +10,7 @@
         :placeholder="placeholder"
         v-model="text"
         @focus="openOptionList"
-        id="inputWithKeyboardOption"
+        ref="inputWithKeyboardOption"
         autocomplete="off"
       )
       .keyboard-option(v-if="isOptionListShow")
@@ -22,6 +22,7 @@
 </template>
 <script lang="ts">
 import Vue from "vue";
+import { isHTMLElement } from "../../utils/types";
 type Data = {
   searchWord: string;
   optionList: string[];
@@ -60,10 +61,9 @@ export default Vue.extend({
   methods: {
     openOptionList(): void {
       this.isOptionListShow = true;
-      const keyboardOption: HTMLInputElement = document.getElementById(
-        "inputWithKeyboardOption"
-      ) as HTMLInputElement;
-      this.$nextTick(() => keyboardOption.focus());
+      const inputWithKeyboardOption = this.$refs.inputWithKeyboardOption;
+      if (!isHTMLElement(inputWithKeyboardOption)) return;
+      this.$nextTick(() => inputWithKeyboardOption.focus());
     },
     closeOptionList(): void {
       this.isOptionListShow = false;
@@ -71,10 +71,9 @@ export default Vue.extend({
     selectOption(option: string): void {
       this.$emit("input", option + this.text);
       this.closeOptionList();
-      const keyboardOption: HTMLInputElement = document.getElementById(
-        "inputWithKeyboardOption"
-      ) as HTMLInputElement;
-      this.$nextTick(() => keyboardOption.focus());
+      const inputWithKeyboardOption = this.$refs.inputWithKeyboardOption;
+      if (!isHTMLElement(inputWithKeyboardOption)) return;
+      this.$nextTick(() => inputWithKeyboardOption.focus());
     }
   }
 });

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,3 @@
+export function isHTMLElement(x: any): x is HTMLElement {
+  return x instanceof HTMLElement;
+}


### PR DESCRIPTION
# 関連するIssue番号
- close #97 

# バグ内容
分量や単位のinputの指定を$refsからidに変えたことで、idが重複して一番最初の要素が選択されるようになってしまった。

# 修正内容
- 要素の指定を$refsに修正
- $refsで取得した要素が、focusメソッドを持つHTMLElementであることを確認するタイプガードを入れた。
- 上記のメソッドを`./src/utils/types.ts`に作成してimportする形に修正

参考: http://www.sky-limit-future.com/entry/vuejs_refs_typescript

# UIの変更点
なし

# 影響範囲

# 動作要件

# 補足
