### PR TITLE
fix: iOSでホーム画面のアイコンを表示させる

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,9 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta name="theme-color" content="#f45d48">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+    <link rel="apple-touch-icon" href="<%= BASE_URL %>images/icons/icon-192x192.png" sizes="192x192"/>
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet">
     <title>レシピメーカー</title>
   </head>


### PR DESCRIPTION
# バグ内容
iOSでホーム画面に追加しても画面のスクショが表示される

# 修正内容
- iOS用のアイコン画像をindex.htmlに埋め込み
- Android用のツールバーの設定もついでに追加

参考:https://qiita.com/w2or3w/items/74a6e471501ee28ee9dd